### PR TITLE
feat: return all healthy endpoints with same priority in failover mode

### DIFF
--- a/coredns/Dockerfile
+++ b/coredns/Dockerfile
@@ -9,7 +9,7 @@ COPY . /go/src/gslb/
 # Build CoreDNS with the GSLB plugin
 RUN git clone https://github.com/coredns/coredns.git /coredns && \
     cd /coredns && \
-    git checkout v1.12.0 && \
+    git checkout v1.12.2 && \
     sed -i '/file:file/i gslb:github.com/dmachard/coredns-gslb' plugin.cfg && \
     go mod edit -replace github.com/dmachard/coredns-gslb=/go/src/gslb && \
     go get github.com/dmachard/coredns-gslb && \


### PR DESCRIPTION
fix #11 

This PR updates the failover mode logic to return all healthy endpoints that share the highest (lowest-numbered) priority, instead of only one. This improves load distribution and resilience when multiple backends are available at the same priority level.

In failover mode, if several endpoints are healthy and have the same priority, all of them are now returned in the DNS response.