### PR TITLE
feat: add gRPC healthcheck support 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,19 +59,35 @@ $ dig -p 8053 @127.0.0.1 webapp.gslb.example.com +short
 172.16.0.10
 ~~~
 
-Testing GeoIP selection with EDNS Client Subnet
+Testing GeoIP from specific region selection with EDNS Client Subnet
 Simulate a query coming from subnet 10.0.0.0/24
 
 ~~~ bash
-$ dig -p 8053 @127.0.0.1 webapp-geo.gslb.example.com +short +subnet=10.1.0.42/24
+$ dig -p 8053 @127.0.0.1 webapp-geoip-region.gslb.example.com +short +subnet=10.1.0.42/24
 172.16.0.10
 ~~~
 
 Simulate a query coming from subnet 192.168.1.0/24
 
 ~~~ bash
-$ dig -p 8053 @127.0.0.1 webapp-geo.gslb.example.com +short +subnet=10.2.0.7/24
+$ dig -p 8053 @127.0.0.1 webapp-geoip-region.gslb.example.com +short +subnet=10.2.0.7/24
 172.16.0.11
+~~~
+
+
+Testing GeoIP with country selection, based EDNS Client Subnet
+Simulate a query coming from an US IP
+
+~~~ bash
+$ dig -p 8053 @127.0.0.1 webapp-geoip-country.gslb.example.com +short +subnet=8.8.8.8/24
+172.16.0.11
+~~~
+
+Simulate a query coming from subnet 192.168.1.0/24
+
+~~~ bash
+$ dig -p 8053 @127.0.0.1 webapp-geoip-country.gslb.example.com +short +subnet=90.29.0.0/24
+172.16.0.10
 ~~~
 
 ## Binary compilation with the plugin

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Unlike many existing solutions, this plugin is designed for non-Kubernetes infra
   - **TCP**: checks if a TCP connection can be established.
   - **ICMP**: checks if the backend responds to ICMP echo (ping).
   - **MySQL**: checks database status
+  - **gRPC**: checks gRPC health service
   - **Custom script**: executes a custom shell script
 - **Selection Modes**:
   - **Failover**: Routes traffic to the highest-priority available backend
@@ -285,9 +286,27 @@ healthchecks:
       query: "SELECT 1"        # Query to execute (optional, default: SELECT 1)
 ```
 
+### gRPC
+
+Checks the health of a gRPC service using the standard gRPC health checking protocol (`grpc.health.v1.Health/Check`).
+
+```yaml
+healthchecks:
+  - type: grpc
+    params:
+      port: 9090                # gRPC port to connect to
+      service: "grpc.health.v1.Health" # Service name (default: "")
+      timeout: 5s               # Timeout for the gRPC request
+```
+
+- `service` can be left empty to check the overall server health, or set to a specific service name.
+
 ### Custom Script
 
-Executes a custom shell script to determine backend health. The script should return exit code 0 for healthy, non-zero for unhealthy.
+Executes a custom shell script to determine backend health. 
+The script should return exit code 0 for healthy, non-zero for unhealthy.
+
+⚠️ **Security Warning**: Custom scripts execute with CoreDNS privileges and have no sandboxing. Use with extreme caution in production environments.
 
 ```yaml
 healthchecks:

--- a/coredns/gslb_config.example.com.yml
+++ b/coredns/gslb_config.example.com.yml
@@ -11,7 +11,7 @@ records:
     scrape_timeout: 5s  # Timeout for health check responses
     backends:
     - address: "172.16.0.10"
-      description: "webapp1"  # Description of the backend location or purpose
+      description: "webapp10"  # Description of the backend location or purpose
       location: "eu-west-1"
       enable: true  # Indicates whether this backend is enabled
       priority: 1  # Priority level (lower number = higher priority)
@@ -29,7 +29,7 @@ records:
             enable_tls: true  # Use TLS for the health check
             skip_tls_verify: true  # Skip TLS certificate validation
     - address: "172.16.0.11"
-      description: "webapp1"  # Description of the backend location or purpose
+      description: "webapp11"  # Description of the backend location or purpose
       location: "eu-west-2"
       enable: true  # Indicates whether this backend is enabled
       priority: 2  # Priority level (lower number = higher priority)
@@ -56,8 +56,7 @@ records:
             timeout: 5s
   
   # Define a GSLB record for webapp2.gslb.example.com with GeoIP mode 
-  # between Paris and London backends
-  webapp-geo-byregion.gslb.example.com.:
+  webapp-geoip-region.gslb.example.com.:
     owner: "admin"
     description: "GeoIP-based routing between Paris and London backends"
     mode: "geoip"  # GeoIP mode: routes clients to the closest backend by location
@@ -67,7 +66,7 @@ records:
     scrape_timeout: 5s
     backends:
     - address: "172.16.0.10"
-      description: "webapp2"
+      description: "webapp10"
       location: "eu-west-1"
       enable: true
       priority: 1
@@ -85,7 +84,7 @@ records:
             enable_tls: true
             skip_tls_verify: true
     - address: "172.16.0.11"
-      description: "webapp2"
+      description: "webapp11"
       location: "eu-west-2"
       enable: true
       priority: 2
@@ -104,18 +103,18 @@ records:
             skip_tls_verify: true
 
   # Define a GSLB record for webapp2.gslb.example.com with GeoIP mode by country
-  webapp-geo-bycountry.gslb.example.com.:
+  webapp-geoip-country.gslb.example.com.:
     owner: "admin"
     description: "GeoIP-based routing by country (using MaxMind GeoLite2-Country.mmdb)"
-    mode: "geoip"  # GeoIP mode: routes clients to the backend matching the client country
+    mode: "geoip"
     record_ttl: 30
     scrape_interval: 10s
     scrape_retries: 1
     scrape_timeout: 5s
     backends:
     - address: "172.16.0.10"
-      description: "webapp2 France"
-      country: "FR"  # Route clients from France to this backend
+      description: "webapp10"
+      country: "FR"
       enable: true
       priority: 1
       healthchecks:
@@ -132,8 +131,8 @@ records:
             enable_tls: true
             skip_tls_verify: true
     - address: "172.16.0.11"
-      description: "webapp2 USA"
-      country: "US"  # Route clients from USA to this backend
+      description: "webapp11"
+      country: "US"
       enable: true
       priority: 2
       healthchecks:
@@ -149,3 +148,25 @@ records:
             expected_body: ""
             enable_tls: true
             skip_tls_verify: true
+
+  # Define a GSLB record for webapp-grpc.gslb.example.com
+  webapp-grpc.gslb.example.com.:
+    owner: "admin"
+    description: "gRPC health checks for webapp12"
+    mode: "geoip"
+    record_ttl: 30
+    scrape_interval: 10s
+    scrape_retries: 1
+    scrape_timeout: 5s
+    backends:
+    - address: "172.16.0.12"
+      description: "webapp12"
+      country: "FR"
+      enable: true
+      priority: 1
+      healthchecks:
+      - type: grpc
+        params:
+          port: 9090
+          service: ""
+          timeout: 5s 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,3 +53,16 @@ services:
     networks:
       gslb_net:
         ipv4_address: 172.16.0.11
+
+  # create webapp to simulate a third web application with gRPC health endpoint
+  webapp12:
+    build:
+      context: ./webapp
+    ports:
+      - "12990:9090"  # Expose gRPC port
+    environment:
+      - APP_NAME=WebApplication12
+      - ENABLE_GRPC_HEALTH=1  # Custom env to enable gRPC health endpoint in the app (implement in webapp if needed)
+    networks:
+      gslb_net:
+        ipv4_address: 172.16.0.12

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -108,6 +108,19 @@ func (hc *HealthCheck) ToSpecificHealthCheck() (GenericHealthCheck, error) {
 		}
 		return &mysqlCheck, nil
 
+	case "grpc":
+		var grpcCheck GRPCHealthCheck
+		grpcCheck.SetDefault()
+		paramsYaml, err := yaml.Marshal(hc.Params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to serialize healthcheck params: %v", err)
+		}
+		err = yaml.Unmarshal(paramsYaml, &grpcCheck)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode gRPC params: %v", err)
+		}
+		return &grpcCheck, nil
+
 	default:
 		return nil, fmt.Errorf("unsupported healthcheck type: %s", hc.Type)
 	}

--- a/healthcheck_grpc.go
+++ b/healthcheck_grpc.go
@@ -1,0 +1,37 @@
+package gslb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type GRPCHealthCheck struct {
+	Host    string
+	Port    int
+	Service string
+	Timeout time.Duration
+}
+
+func (h *GRPCHealthCheck) Check() error {
+	addr := fmt.Sprintf("%s:%d", h.Host, h.Port)
+	ctx, cancel := context.WithTimeout(context.Background(), h.Timeout)
+	defer cancel()
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	client := healthpb.NewHealthClient(conn)
+	resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{Service: h.Service})
+	if err != nil {
+		return err
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		return fmt.Errorf("gRPC health status: %s", resp.Status.String())
+	}
+	return nil
+}

--- a/healthcheck_grpc.go
+++ b/healthcheck_grpc.go
@@ -35,3 +35,38 @@ func (h *GRPCHealthCheck) Check() error {
 	}
 	return nil
 }
+
+func (h *GRPCHealthCheck) SetDefault() {
+	if h.Timeout == 0 {
+		h.Timeout = 5 * time.Second
+	}
+	if h.Service == "" {
+		h.Service = ""
+	}
+}
+
+func (h *GRPCHealthCheck) PerformCheck(backend *Backend, fqdn string, maxRetries int) bool {
+	host := h.Host
+	if host == "" && backend != nil {
+		host = backend.Address
+	}
+	check := &GRPCHealthCheck{
+		Host:    host,
+		Port:    h.Port,
+		Service: h.Service,
+		Timeout: h.Timeout,
+	}
+	return check.Check() == nil
+}
+
+func (h *GRPCHealthCheck) GetType() string {
+	return "grpc"
+}
+
+func (h *GRPCHealthCheck) Equals(other GenericHealthCheck) bool {
+	otherGrpc, ok := other.(*GRPCHealthCheck)
+	if !ok {
+		return false
+	}
+	return h.Host == otherGrpc.Host && h.Port == otherGrpc.Port && h.Service == otherGrpc.Service && h.Timeout == otherGrpc.Timeout
+}

--- a/healthcheck_grpc_test.go
+++ b/healthcheck_grpc_test.go
@@ -1,0 +1,20 @@
+package gslb
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGRPCHealthCheck_Check(t *testing.T) {
+	hc := &GRPCHealthCheck{
+		Host:    "localhost",
+		Port:    50051, // Use a test gRPC server in real tests
+		Service: "",
+		Timeout: 1 * time.Second,
+	}
+	// This test expects no gRPC server running, so it should fail
+	err := hc.Check()
+	if err == nil {
+		t.Error("expected error when no gRPC server is running")
+	}
+}

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -19,3 +19,16 @@ func TestToSpecificHealthCheck_Unsupported(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "unsupported healthcheck type: unsupported_type", err.Error())
 }
+
+// Test that all known healthcheck types are handled in ToSpecificHealthCheck
+func TestToSpecificHealthCheck_AllTypesHandled(t *testing.T) {
+	types := []string{"http", "icmp", "tcp", "custom", "mysql", "grpc"}
+	for _, typ := range types {
+		hc := &HealthCheck{
+			Type:   typ,
+			Params: map[string]interface{}{},
+		}
+		_, err := hc.ToSpecificHealthCheck()
+		assert.NoErrorf(t, err, "Type '%s' should be handled in ToSpecificHealthCheck", typ)
+	}
+}

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -6,6 +6,7 @@ COPY ./server.py /app/
 COPY ./init.sh /app/
 COPY ./requirements.txt /app/
 
+RUN pip install --no-cache-dir -r /app/requirements.txt
 RUN chmod +x /app/init.sh
 
 WORKDIR /app

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+grpcio
+grpcio-health-checking

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1,35 +1,72 @@
+import os
+import sys
+import threading
 import http.server
 import ssl
 import argparse
+from concurrent import futures
 
-from http.server import  BaseHTTPRequestHandler
+# gRPC imports
+try:
+    import grpc
+    from grpc_health.v1 import health, health_pb2_grpc
+    GRPC_AVAILABLE = True
+except ImportError:
+    GRPC_AVAILABLE = False
 
+from http.server import BaseHTTPRequestHandler
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description="HTTPS Server")
-parser.add_argument('--port', type=int, default=443, help='Port to listen on')
-parser.add_argument('--certfile', type=str, required=True, help='Path to SSL certificate file')
-parser.add_argument('--keyfile', type=str, required=True, help='Path to SSL key file')
-parser.add_argument('--name', type=str, required=True, help='Name of the application')
+def run_https_server(port, name, certfile, keyfile):
+    class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            msg = f"Welcome to {name}"
+            self.wfile.write(msg.encode())
 
-args = parser.parse_args()
+    httpd = http.server.HTTPServer(('0.0.0.0', port), SimpleHTTPRequestHandler)
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    httpd.serve_forever()
 
-class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.end_headers()
-        msg = f"Welcome to {args.name}"
-        self.wfile.write(msg.encode())
+def run_grpc_health_server(port):
+    import grpc
+    from grpc_health.v1 import health, health_pb2_grpc, health_pb2
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
+    health_servicer = health.HealthServicer()
+    health_pb2_grpc.add_HealthServicer_to_server(health_servicer, server)
+    health_servicer.set('', health_pb2.HealthCheckResponse.SERVING)
+    server.add_insecure_port(f'[::]:{port}')
+    server.start()
+    server.wait_for_termination()
 
-# Create the HTTP server
-httpd = http.server.HTTPServer(('0.0.0.0', args.port), SimpleHTTPRequestHandler)
+def main():
+    parser = argparse.ArgumentParser(description="HTTPS and optional gRPC Health Server")
+    parser.add_argument('--port', type=int, default=443, help='Port to listen on (HTTPS)')
+    parser.add_argument('--certfile', type=str, required=True, help='Path to SSL certificate file')
+    parser.add_argument('--keyfile', type=str, required=True, help='Path to SSL key file')
+    parser.add_argument('--name', type=str, required=True, help='Name of the application')
+    parser.add_argument('--grpc-port', type=int, default=9090, help='Port for gRPC health server')
+    args = parser.parse_args()
 
-# Create an SSL context and wrap the socket
-context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-context.load_cert_chain(certfile=args.certfile, keyfile=args.keyfile)
+    enable_grpc = os.environ.get('ENABLE_GRPC_HEALTH', '0') == '1'
 
-# Apply SSL context to the server's socket
-httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    threads = []
+    t1 = threading.Thread(target=run_https_server, args=(args.port, args.name, args.certfile, args.keyfile))
+    t1.start()
+    threads.append(t1)
 
-# Start the server
-httpd.serve_forever()
+    if enable_grpc:
+        if not GRPC_AVAILABLE:
+            print("gRPC health server requested but grpcio and grpcio-health-checking are not installed.", file=sys.stderr)
+            sys.exit(1)
+        t2 = threading.Thread(target=run_grpc_health_server, args=(args.grpc_port,))
+        t2.start()
+        threads.append(t2)
+
+    for t in threads:
+        t.join()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add gRPC healthcheck implementation using grpc.health.v1.Health/Check
- Update README with gRPC healthcheck documentation and YAML example
- Add unit test for gRPC healthcheck
- List gRPC in healthcheck features and configuration
- This enables health monitoring of gRPC backends in GSLB deployments.