### PR TITLE
feat(config): default values for GSLB records in YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <img src="https://goreportcard.com/badge/github.com/dmachard/coredns-gslb" alt="Go Report"/>
   <img src="https://img.shields.io/badge/go%20lint%20rules-8-green" alt="Go lint"/>
-  <img src="https://img.shields.io/badge/go%20tests-139-green" alt="Go tests"/>
+  <img src="https://img.shields.io/badge/go%20tests-142-green" alt="Go tests"/>
   <img src="https://img.shields.io/badge/go%20coverage-75%25-green" alt="Go coverage"/>
-  <img src="https://img.shields.io/badge/lines%20of%20code-3032-blue" alt="Lines of code"/>
+  <img src="https://img.shields.io/badge/lines%20of%20code-3262-blue" alt="Lines of code"/>
   <img src="https://img.shields.io/badge/integration%20tests-7-blue" alt="Integration tests"/>
 </p>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,36 @@ records:
           enable_tls: true
 ~~~
 
+### Using the `defaults` block in YAML zone files
+
+You can define a `defaults` block at the top of your zone YAML file to avoid repeating common fields in every record. Any field defined in `defaults` will be automatically applied to all records, unless a record explicitly overrides that field.
+
+**Example:**
+
+~~~yaml
+defaults:
+  owner: admin
+  record_ttl: 30
+  scrape_interval: 10s
+  scrape_retries: 1
+  scrape_timeout: 5s
+
+records:
+  web1.example.org.:
+    mode: failover
+    # Inherits all defaults above
+  web2.example.org.:
+    mode: failover
+    owner: alice  # Overrides the default owner
+    record_ttl: 60  # Overrides the default TTL
+~~~
+
+In this example:
+- `web1.example.org.` will have `owner=admin`, `record_ttl=30`, etc. (from defaults)
+- `web2.example.org.` will have `owner=alice` and `record_ttl=60`, but will inherit the other defaults.
+
+This makes your YAML files much more concise and easier to maintain.
+
 ### GeoIP
 
 #### MaxMind Databases

--- a/tests/db.app-x.gslb.example.com.yml
+++ b/tests/db.app-x.gslb.example.com.yml
@@ -1,3 +1,9 @@
+defaults:
+  owner: admin
+  record_ttl: 30
+  scrape_interval: 10s
+  scrape_retries: 1
+  scrape_timeout: 5s
 healthcheck_profiles:
   grpc_default:
     params:
@@ -62,11 +68,6 @@ records:
         priority: 1
     description: gRPC health checks for webapp12
     mode: geoip
-    owner: admin
-    record_ttl: 30
-    scrape_interval: 10s
-    scrape_retries: 1
-    scrape_timeout: 5s
   webapp-lua.app-x.gslb.example.com.:
     backends:
       - address: 172.16.0.10
@@ -76,11 +77,6 @@ records:
         priority: 1
     description: Backend with Lua healthcheck (JSON via http_get + json_decode)
     mode: failover
-    owner: admin
-    record_ttl: 30
-    scrape_interval: 10s
-    scrape_retries: 1
-    scrape_timeout: 5s
   webapp.app-x.gslb.example.com.:
     backends:
       - address: 172.16.0.10
@@ -100,8 +96,3 @@ records:
         priority: 2
     description: Dynamic DNS responses based on backend status
     mode: failover
-    owner: admin
-    record_ttl: 30
-    scrape_interval: 10s
-    scrape_retries: 1
-    scrape_timeout: 5s

--- a/tests/db.app-y.gslb.example.com.yml
+++ b/tests/db.app-y.gslb.example.com.yml
@@ -1,3 +1,9 @@
+defaults:
+  owner: admin
+  record_ttl: 30
+  scrape_interval: 10s
+  scrape_retries: 1
+  scrape_timeout: 5s
 healthcheck_profiles:
   https_default:
     params:
@@ -31,11 +37,6 @@ records:
         priority: 2
     description: GeoIP-based routing by country (using MaxMind GeoLite2-Country.mmdb)
     mode: geoip
-    owner: admin
-    record_ttl: 30
-    scrape_interval: 10s
-    scrape_retries: 1
-    scrape_timeout: 5s
   webapp-geoip-loc.app-y.gslb.example.com.:
     backends:
       - address: 172.16.0.10
@@ -54,8 +55,3 @@ records:
         priority: 2
     description: GeoIP-based routing between Paris and London backends
     mode: geoip
-    owner: admin
-    record_ttl: 30
-    scrape_interval: 10s
-    scrape_retries: 1
-    scrape_timeout: 5s


### PR DESCRIPTION

- Added support for default values in the GSLB configuration, allowing records to inherit properties such as owner, record_ttl, and scrape settings.
- Updated the loadConfigFile function to merge defaults with individual record settings.
- Enhanced tests to verify that defaults are correctly applied and overridden where specified.
- Updated documentation and example YAML files to reflect the new default configuration structure.