### PR TITLE
chore: update CoreDNS version to v1.12.4 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    regex-managers:
+      - file: "Dockerfile"
+        matchers:
+          - pattern: 'ARG COREDNS_VERSION=(?<version>.*)'
+        dependency-name: "coredns/coredns"
+        versioning-template: "v<version>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src
 COPY . /go/src/gslb/
 
 # Build CoreDNS with the GSLB plugin
-ARG COREDNS_VERSION=v1.12.3
+ARG COREDNS_VERSION=v1.12.4
 ARG GSLB_VERSION=dev
 RUN git clone https://github.com/coredns/coredns.git /coredns && \
     cd /coredns && \


### PR DESCRIPTION
update CoreDNS version to v1.12.4 and add regex manager for Dockerfile