### PR TITLE
Log backend health changes with higher log level

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -227,10 +227,11 @@ func (b *Backend) runHealthChecks(maxRetries int, scrapeTimeout time.Duration) {
 
 	// Log backend health changes with higher log level
 	if b.Alive != oldAlive {
-		log.Infof("[%s] backend status [address=%s]: healthchecks=%s alive=%v", b.Fqdn, b.Address, healthChecksList, b.Alive)
-	} else {
-		log.Debugf("[%s] backend status [address=%s]: healthchecks=%s alive=%v", b.Fqdn, b.Address, healthChecksList, b.Alive)
+		log.Infof("[%s] backend status change [address=%s]: alive changed from %v to %v", b.Fqdn, b.Address, oldAlive, b.Alive)
 	}
+
+	// Keep old log format for log parsing
+	log.Debugf("[%s] backend status [address=%s]: healthchecks=%s alive=%v", b.Fqdn, b.Address, healthChecksList, b.Alive)
 }
 
 func (b *Backend) IsHealthy() bool {


### PR DESCRIPTION
When updating the backend object with the alive result. Compare alive with previous alive state and log backend status with loglevel Info instead of Debug von current vs previous state differs.

We can discuss about the LogLevel (Info vs Warning) but state change be more important then Debug. If we keep Warning to GSLB warnings, then this is okay.

Fixes #66 