### PR TITLE
chore: Update CoreDNS version to 1.14.1 in release workflow and Docke…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 env:
-  COREDNS_VERSION: "1.14.0"
+  COREDNS_VERSION: "1.14.1"
   GO_VERSION: "1.24"
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src
 COPY . /go/src/gslb/
 
 # Build CoreDNS with the GSLB plugin
-ARG COREDNS_VERSION=v1.14.0
+ARG COREDNS_VERSION=v1.14.1
 ARG GSLB_VERSION=dev
 RUN git clone https://github.com/coredns/coredns.git /coredns && \
     cd /coredns && \


### PR DESCRIPTION
Update CoreDNS version to 1.14.1 in release workflow and Dockerfile.