### PR TITLE
feat: added mtls auth and TLS SNI support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,8 +72,8 @@ jobs:
           echo "coredns_gslb did not become ready in time" >&2
           exit 1
 
-      - name: Wait for healthcheck to be ready (15s)
-        run: sleep 15
+      - name: Wait for healthcheck to be ready (30s)
+        run: sleep 30
 
       - name: Check initial dig (should be 172.16.0.10)
         run: |
@@ -171,7 +171,7 @@ jobs:
         run: |
           resp=$(curl -s -X GET http://127.0.0.1:8080/api/overview | jq 'map(length) | add')
           echo "Got Nb records: $resp"
-          [ "$resp" = "6" ] || (echo "Expected 6 records, got $resp" && exit 1)
+          [ "$resp" = "7" ] || (echo "Expected 7 records, got $resp" && exit 1)
 
       - name: Show docker-compose logs on failure
         if: failure()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,8 +72,8 @@ jobs:
           echo "coredns_gslb did not become ready in time" >&2
           exit 1
 
-      - name: Wait for healthcheck to be ready (30s)
-        run: sleep 30
+      - name: Wait for healthcheck to be ready (15s)
+        run: sleep 15
 
       - name: Check initial dig (should be 172.16.0.10)
         run: |
@@ -84,8 +84,8 @@ jobs:
       - name: Stop webapp10
         run: sudo docker-compose -f docker-compose.dev.yml stop webapp10
 
-      - name: Wait for healthcheck to update (15s)
-        run: sleep 15
+      - name: Wait for healthcheck to update (35s) # TTL + 5s
+        run: sleep 35
 
       - name: Check dig after webapp10 stopped (should be 172.16.0.11)
         run: |
@@ -96,8 +96,8 @@ jobs:
       - name: Restart webapp10
         run: sudo docker-compose -f docker-compose.dev.yml start webapp10
 
-      - name: Wait for healthcheck to update (15s)
-        run: sleep 15
+      - name: Wait for healthcheck to update (35s) # TTL + 5s
+        run: sleep 35
 
       - name: Check dig after webapp10 restarted (should be 172.16.0.10)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,9 @@ Before opening a pull request, please read the following guidelines to ensure sm
 
 ## Running the Dev Environment with Docker compose
 
+Certificates are generated on-demand for TLS and mTLS validation
+see the cert_gen folder and the webapp init.sh for details
+
 Build CoreDNS with the plugin
 
 ~~~ bash
@@ -52,7 +55,7 @@ Restart Webapp 1:
 sudo docker compose -f docker-compose.dev.yml start webapp10
 ~~~
 
-Wait a few seconds, then resolve again to observe traffic switching back to Webapp 1:
+Wait a few seconds, then resolve again to observe traffic switching back to Webapp 10:
 
 ~~~ bash
 $ dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short
@@ -90,6 +93,12 @@ $ dig -p 8053 @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +sub
 172.16.0.10
 ~~~
 
+Cleanup docker compose artifacts, the `-v` flag ensures the devcert volume is cleaned up
+
+~~~ bash
+sudo docker compose -f docker-compose.dev.yml down -v
+~~~
+
 ## Binary compilation with the plugin
 
 The `GSLB` plugin must be integrated into CoreDNS during compilation.
@@ -117,23 +126,34 @@ go test -timeout 10s -cover -v . -run TestGSLB_PickFailoverBackend
 
 ## Run linters
 
-Install linter
+**Install make:**
 
+**Debian based:**
 ```bash
 sudo apt install build-essential
+```
+**RHEL based:**
+```bash
+sudo dnf group install c-development
+```
+
+**Install linter:**
+
+```bash
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 ```
 
-Execute linter before to commit
+**Execute linter before commit:**
 
 ```bash
 make lint
 ```
+
 # Update CoreDNS
 
 ```bash
-go mod edit -go=1.24
-go get github.com/coredns/coredns@v1.12.3
-go get github.com/miekg/dns@v1.1.68
+go mod edit -go=1.25
+go get github.com/coredns/coredns@v1.14.3
+go get github.com/miekg/dns@v1.1.72
 go mod tidy
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,11 +6,22 @@ networks:
         - subnet: 172.16.0.0/24
 
 services:
+  # generate rootca, server and client certificates
+  gen_certs:
+    build:
+      context: ./tests/gen_certs
+    container_name: gen_certs
+    volumes:
+      - devcerts:/app/certs/
   # create coredns with GSLB plugin
   coredns_gslb:
     build:
       context: .
       dockerfile: ./Dockerfile
+    depends_on:
+      - webapp10
+      - webapp11
+      - webapp12
     container_name: coredns
     ports:
       - "8053:53/udp"
@@ -18,6 +29,7 @@ services:
       - "9153:9153/tcp"
       - "8080:8080/tcp"
     volumes:
+      - devcerts:/certs/:ro
       - ./tests/Corefile:/Corefile
       - ./tests/:/coredns/
     command: -conf /Corefile
@@ -31,8 +43,17 @@ services:
   webapp10:
     build:
       context: ./tests/webapp
+      extra_hosts:
+        - "webapplication10=172.16.0.10"
+        - "cdns-gslb-server=172.16.0.10"
+        - "localhost=172.16.0.10"
+    depends_on:
+      - gen_certs
+    container_name: webapp10
     ports:
       - "10443:443"
+    volumes:
+      - devcerts:/app/certs/:ro
     environment:
       - APP_NAME=WebApplication10
     networks:
@@ -43,8 +64,17 @@ services:
   webapp11:
     build:
       context: ./tests/webapp
+      extra_hosts:
+        - "webapplication11=172.16.0.11"
+        - "cdns-gslb-server=172.16.0.11"
+        - "localhost=172.16.0.11"
+    depends_on:
+      - gen_certs
+    container_name: webapp11
     ports:
       - "11443:443"
+    volumes:
+      - devcerts:/app/certs/:ro
     environment:
       - APP_NAME=WebApplication11
     networks:
@@ -55,8 +85,17 @@ services:
   webapp12:
     build:
       context: ./tests/webapp
+      extra_hosts:
+        - "webapplication12=172.16.0.12"
+        - "cdns-gslb-server=172.16.0.12"
+        - "localhost=172.16.0.12"
+    depends_on:
+      - gen_certs
+    container_name: webapp12
     ports:
       - "12990:9090"  # Expose gRPC port
+    volumes:
+      - devcerts:/app/certs/:ro
     environment:
       - APP_NAME=WebApplication12
       - ENABLE_GRPC_HEALTH=1  # Custom env to enable gRPC health endpoint in the app (implement in webapp if needed)
@@ -101,3 +140,4 @@ services:
 volumes:
   prometheus_data:
   grafana_data:
+  devcerts:

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -83,6 +83,15 @@ Checks the health of an HTTP or HTTPS endpoint by making a request and validatin
 The HTTP health check connects to `backend.address` on given `params.port`. The `Host` header is set based on
 `params.host`, which does not overwrite the target address. HTTP forwards are not followed.
 
+mTLS is enabled by setting `params.enable_tls` to `true` and then supplying both of `params.cert_path` and `params.key_path`
+there is the optional `params.ca_path` as well for using private PKI, this can be the Root CA or the chain depending on
+your server implementation of certificate checking strictness. If the CA path is omitted, the trusted root store is used.
+
+If `params.enable_tls` is not enabled, mTLS will not be attempted, be explicit in your configuration intention!
+Also, if `params.ca_path` is set but `params.skip_tls_verify` is set to true, it will have a net-zero effect.
+
+Additionally, the `params.host` is used as the SNI parameter in the Client Hello for multiplexed server targets.
+
 Debugging HTTP health checks is easier when the user agent is clearly visible in the server logs, so a predefined User-Agent value is set to CoreDNS/GSLB/....
 
 ```yaml
@@ -98,6 +107,9 @@ healthchecks:
       expected_code: 200       # Expected HTTP status code
       expected_body: ""        # Expected response body (empty means no body validation)
       enable_tls: true         # Use TLS for the health check (HTTPS)
+      cert_path: "cert.pem"    # Define path to client certificate for mTLS
+      key_path: "key.pem"      # Define path for client private key for mTLS
+      ca_path: "cacert.pem"    # Define optional path to trusted Private RootCA File or Chain
       skip_tls_verify: true    # Skip TLS certificate validation
 ```
 

--- a/gtls.go
+++ b/gtls.go
@@ -1,0 +1,91 @@
+package gslb
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func setTLSDefaults(ctls *tls.Config) {
+	ctls.MinVersion = tls.VersionTLS12
+	ctls.MaxVersion = tls.VersionTLS13
+	ctls.CipherSuites = []uint16{
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+}
+
+// NewTLSConfig returns a TLS config that includes a certificate and key pair
+// If caPath is empty, default root store will be used
+// If certPath or keyPath are empty, client certificate will not be loaded
+func NewTLSClientConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
+	var tlsConfig *tls.Config
+	roots, err := loadRoots(caPath)
+	if err != nil {
+		return nil, err
+	}
+	if certPath != "" && keyPath != "" {
+		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("could not load TLS cert: %w", err)
+		}
+		tlsConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      roots,
+		}
+	} else {
+		tlsConfig = &tls.Config{
+			RootCAs: roots,
+		}
+	}
+	setTLSDefaults(tlsConfig)
+
+	return tlsConfig, nil
+}
+
+func loadRoots(caPath string) (*x509.CertPool, error) {
+	if caPath == "" {
+		return nil, nil
+	}
+
+	roots := x509.NewCertPool()
+	pem, err := os.ReadFile(filepath.Clean(caPath))
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", caPath, err)
+	}
+	ok := roots.AppendCertsFromPEM(pem)
+	if !ok {
+		return nil, fmt.Errorf("could not read root certs: %w", err)
+	}
+	return roots, nil
+}
+
+func NewHTTPSTransport(cc *tls.Config) *http.Transport {
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     cc,
+		MaxIdleConnsPerHost: 25,
+	}
+
+	return tr
+}

--- a/gtls_test.go
+++ b/gtls_test.go
@@ -1,0 +1,97 @@
+package gslb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func getPEMFiles(t *testing.T) (cert, key, ca string) {
+	t.Helper()
+	tempDir, err := writePEMFiles(t)
+	if err != nil {
+		t.Fatalf("Could not write PEM files: %s", err)
+	}
+
+	cert = filepath.Join(tempDir, "cert.pem")
+	key = filepath.Join(tempDir, "key.pem")
+	ca = filepath.Join(tempDir, "ca.pem")
+
+	return
+}
+
+func TestNewTLSClientConfig(t *testing.T) {
+	cert, key, ca := getPEMFiles(t)
+	_, err := NewTLSClientConfig(cert, key, ca)
+	if err != nil {
+		t.Errorf("Failed to create TLSConfig: %s", err)
+	}
+}
+
+func TestNewHTTPSTransport(t *testing.T) {
+	cert, key, ca := getPEMFiles(t)
+
+	cc, err := NewTLSClientConfig(cert, key, ca)
+	if err != nil {
+		t.Errorf("Failed to create TLSConfig: %s", err)
+	}
+
+	tr := NewHTTPSTransport(cc)
+	if tr == nil {
+		t.Errorf("Failed to create https transport with cc")
+	}
+
+	tr = NewHTTPSTransport(nil)
+	if tr == nil {
+		t.Errorf("Failed to create https transport without cc")
+	}
+}
+
+// WritePEMFiles creates a tmp dir with ca.pem, cert.pem, and key.pem
+func writePEMFiles(t *testing.T) (string, error) {
+	t.Helper()
+	tempDir := t.TempDir()
+
+	data := `-----BEGIN CERTIFICATE-----
+MIIBizCCAT2gAwIBAgIUM3BRGwa3MOn9ZZjjkBm6SpWVyIAwBQYDK2VwMBoxGDAW
+BgNVBAMMD2NvcmVkbnMtZ3NsYi1jYTAeFw0yNjA1MDUxNDMwNTFaFw0yNjA2MDQx
+NDMwNTFaMBoxGDAWBgNVBAMMD2NvcmVkbnMtZ3NsYi1jYTAqMAUGAytlcAMhAGyt
+VrpY/nAJeWjSwqN0xrfbrHZIu6HwRVLpLkPktZ2Io4GUMIGRMB0GA1UdDgQWBBSO
+rrsTnQfvh2dMifRkp6OZSvZqRjBVBgNVHSMETjBMgBSOrrsTnQfvh2dMifRkp6OZ
+SvZqRqEepBwwGjEYMBYGA1UEAwwPY29yZWRucy1nc2xiLWNhghQzcFEbBrcw6f1l
+mOOQGbpKlZXIgDAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIBBjAFBgMrZXADQQCQ
+3NUdBtmZkPupsOIj442J08CeG1dsHyT+f0jX0THtfx5w1/wHX52OJtOnIDxSBzHv
+K8dIO5Sl4vXm3wuG8QEG
+-----END CERTIFICATE-----`
+	path := filepath.Join(tempDir, "ca.pem")
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		return "", err
+	}
+	data = `-----BEGIN CERTIFICATE-----
+MIIBzDCCAX6gAwIBAgIUFnjMPKZyapZluZRgQdzxVaUSvaMwBQYDK2VwMBoxGDAW
+BgNVBAMMD2NvcmVkbnMtZ3NsYi1jYTAeFw0yNjA1MDUxNDMwNTFaFw0yNjA2MDQx
+NDMwNTFaMBsxGTAXBgNVBAMMEGNkbnMtZ3NsYi1jbGllbnQwKjAFBgMrZXADIQCT
+pbb/9fjix7kUFpUycEr274PoQDo5mytYHSoBH5stoqOB1DCB0TAJBgNVHRMEAjAA
+MB0GA1UdDgQWBBR+8ZU50qEZ2TKFRZlgVy2uSdxvqTBVBgNVHSMETjBMgBSOrrsT
+nQfvh2dMifRkp6OZSvZqRqEepBwwGjEYMBYGA1UEAwwPY29yZWRucy1nc2xiLWNh
+ghQzcFEbBrcw6f1lmOOQGbpKlZXIgDALBgNVHQ8EBAMCBaAwEwYDVR0lBAwwCgYI
+KwYBBQUHAwIwLAYDVR0RBCUwI4IQY2Rucy1nc2xiLWNsaWVudIIJbG9jYWxob3N0
+hwSsEAAJMAUGAytlcANBAD5Ctw4q7RBDTgeDx7H4sojcHfkkGawrk6UsRGKPbpqI
+mHhwEoKCDlS6kAh5B4fmyXbT/fWRPrn15mxZh3dfSQE=
+-----END CERTIFICATE-----`
+	path = filepath.Join(tempDir, "cert.pem")
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		return "", err
+	}
+
+	//nolint:gosec // Test fixture private key.
+	data = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIAyPq2Ewm+RPPw617qcne588ouPmlY1v3Jed0M+F1Y9k
+-----END PRIVATE KEY-----`
+	path = filepath.Join(tempDir, "key.pem")
+	if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+		return "", err
+	}
+
+	return tempDir, nil
+}

--- a/healthcheck_http.go
+++ b/healthcheck_http.go
@@ -19,6 +19,9 @@ import (
 type HTTPHealthCheck struct {
 	Port          int               `yaml:"port" default:"443"`
 	EnableTLS     bool              `yaml:"enable_tls" default:"true"`
+	Cert          string            `yaml:"cert_path" default:""`
+	Key           string            `yaml:"key_path" default:""`
+	CA            string            `yaml:"ca_path" default:""`
 	URI           string            `yaml:"uri" default:"/"`
 	Method        string            `yaml:"method" default:"GET"`
 	Host          string            `yaml:"host" default:"localhost"`
@@ -41,7 +44,8 @@ func (h *HTTPHealthCheck) GetType() string {
 }
 
 // createHTTPClient returns an http client with appropriate transport settings, including timeout and TLS configuration.
-func createHTTPClient(enableTLS bool, skipTLSVerify bool, timeout time.Duration) *http.Client {
+func createHTTPClient(enableTLS, skipTLSVerify bool, timeout time.Duration, srvname, cert, key, cacert string) *http.Client {
+	var err error
 	// Configure net.Dialer with sensible defaults
 	dialer := &net.Dialer{
 		Timeout:   timeout,
@@ -51,9 +55,13 @@ func createHTTPClient(enableTLS bool, skipTLSVerify bool, timeout time.Duration)
 	// Configure TLS settings if needed
 	var tlsConfig *tls.Config
 	if enableTLS {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: skipTLSVerify,
+		tlsConfig, err = NewTLSClientConfig(cert, key, cacert)
+		if err != nil {
+			tlsConfig = &tls.Config{}
 		}
+		// must add the servername for SNI support
+		tlsConfig.ServerName = srvname
+		tlsConfig.InsecureSkipVerify = skipTLSVerify
 	}
 
 	// Construct custom transport with the dialer and TLS config
@@ -69,10 +77,6 @@ func createHTTPClient(enableTLS bool, skipTLSVerify bool, timeout time.Duration)
 	return &http.Client{
 		Transport: transport,
 		Timeout:   timeout,
-		// do not follow redirects
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
 	}
 }
 
@@ -159,7 +163,7 @@ func (h *HTTPHealthCheck) PerformCheck(backend *Backend, fqdn string, maxRetries
 		return false
 	}
 
-	client := createHTTPClient(h.EnableTLS, h.SkipTLSVerify, t)
+	client := createHTTPClient(h.EnableTLS, h.SkipTLSVerify, t, h.Host, h.Cert, h.Key, h.CA)
 
 	// Create HTTP request
 	ctx, cancel := context.WithTimeout(context.Background(), t)
@@ -201,6 +205,9 @@ func (h *HTTPHealthCheck) Equals(other GenericHealthCheck) bool {
 	// Compare all fields
 	if h.Port != otherHTTP.Port ||
 		h.EnableTLS != otherHTTP.EnableTLS ||
+		h.Cert != otherHTTP.Cert ||
+		h.Key != otherHTTP.Key ||
+		h.CA != otherHTTP.CA ||
 		h.URI != otherHTTP.URI ||
 		h.Method != otherHTTP.Method ||
 		h.Host != otherHTTP.Host ||

--- a/healthcheck_http.go
+++ b/healthcheck_http.go
@@ -77,6 +77,10 @@ func createHTTPClient(enableTLS, skipTLSVerify bool, timeout time.Duration, srvn
 	return &http.Client{
 		Transport: transport,
 		Timeout:   timeout,
+		// do not follow redirects
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 }
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -117,9 +117,9 @@ func TestLoadRealConfig(t *testing.T) {
 
 	// Verify healthcheck profiles were loaded
 	assert.NotNil(t, g.HealthcheckProfiles)
-	assert.Len(t, g.HealthcheckProfiles, 4) // https_default, icmp_default, grpc_default, lua_default
+	assert.Len(t, g.HealthcheckProfiles, 5) // https_default, mtls_default, icmp_default, grpc_default, lua_default
 
-	expectedProfiles := []string{"https_default", "icmp_default", "grpc_default", "lua_default"}
+	expectedProfiles := []string{"https_default", "mtls_default", "icmp_default", "grpc_default", "lua_default"}
 	for _, profileName := range expectedProfiles {
 		assert.Contains(t, g.HealthcheckProfiles, profileName, "Should contain profile %s", profileName)
 	}
@@ -128,7 +128,7 @@ func TestLoadRealConfig(t *testing.T) {
 	assert.NotNil(t, g.Records)
 	assert.Len(t, g.Records, 1)
 	for _, recs := range g.Records {
-		assert.Len(t, recs, 3)
+		assert.Len(t, recs, 4)
 	}
 
 	zone = "webapp.app-x.gslb.example.com."

--- a/tests/db.app-x.gslb.example.com.yml
+++ b/tests/db.app-x.gslb.example.com.yml
@@ -13,6 +13,7 @@ healthcheck_profiles:
     type: grpc
   https_default:
     params:
+      ca_path: /certs/ca/cert.pem
       enable_tls: true
       expected_body: ""
       expected_code: 200
@@ -20,7 +21,23 @@ healthcheck_profiles:
       host: localhost
       method: GET
       port: 443
-      skip_tls_verify: true
+      skip_tls_verify: false
+      timeout: 5s
+      uri: /
+    type: http
+  mtls_default:
+    params:
+      ca_path: /certs/ca/cert.pem
+      cert_path: /certs/client/cert.pem
+      key_path: /certs/client/key.pem
+      enable_tls: true
+      expected_body: ""
+      expected_code: 200
+      headers: null
+      host: cdns-gslb-server
+      method: GET
+      port: 443
+      skip_tls_verify: false
       timeout: 5s
       uri: /
     type: http
@@ -96,3 +113,21 @@ records:
         priority: 2
     description: Dynamic DNS responses based on backend status
     mode: failover
+  webapp-mtls.app-x.gslb.example.com.:
+    backends:
+      - address: 172.16.0.10
+        description: webapp10
+        enable: true
+        healthchecks:
+          - mtls_default
+        location: eu-west-1
+        priority: 1
+      - address: 172.16.0.11
+        description: webapp11
+        enable: true
+        healthchecks:
+          - mtls_default
+        location: eu-west-2
+        priority: 2
+    description: Dynamic DNS responses based on backend status
+    mode: random

--- a/tests/db.app-y.gslb.example.com.yml
+++ b/tests/db.app-y.gslb.example.com.yml
@@ -7,14 +7,15 @@ defaults:
 healthcheck_profiles:
   https_default:
     params:
+      ca_path: /certs/ca/cert.pem
       enable_tls: true
       expected_body: ""
       expected_code: 200
       headers: null
-      host: localhost
+      host: cdns-gslb-server
       method: GET
       port: 443
-      skip_tls_verify: true
+      skip_tls_verify: false
       timeout: 5s
       uri: /
     type: http
@@ -34,7 +35,7 @@ records:
         enable: true
         healthchecks:
           - https_default
-        priority: 2
+        priority: 1
     description: GeoIP-based routing by country (using MaxMind GeoLite2-Country.mmdb)
     mode: geoip
   webapp-geoip-loc.app-y.gslb.example.com.:
@@ -52,7 +53,7 @@ records:
         healthchecks:
           - https_default
         location: eu-west-2
-        priority: 2
+        priority: 1
     description: GeoIP-based routing between Paris and London backends
     mode: geoip
 

--- a/tests/gen_certs/Dockerfile
+++ b/tests/gen_certs/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.13-slim
+
+RUN mkdir -p /app/gen_certs
+
+COPY ./rootca.cnf /app/gen_certs/
+COPY ./gencerts.sh /app/
+RUN chmod +x /app/gencerts.sh
+
+WORKDIR /app
+CMD ["/app/gencerts.sh"]

--- a/tests/gen_certs/gencerts.sh
+++ b/tests/gen_certs/gencerts.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# mTLS verification requires a common trusted root CA, the rootca.cnf is from
+#  my local machine and then modified for easy cert creation
+#
+# See the following links for more information:
+# https://docs.openssl.org/3.0/man1/openssl-ca/#examples
+# https://docs.openssl.org/3.0/man5/x509v3_config/#key-usage
+#
+# Create self-signed certificate w/ root CA extensions
+#
+
+if [ -f /app/certs/ca/cert.pem ]; then
+exit 0
+fi
+
+mkdir -p certs/client certs/ca
+cp gen_certs/rootca.cnf certs/
+
+openssl req -x509 -new -newkey ED25519 -noenc -config gen_certs/rootca.cnf \
+ -subj "/CN=coredns-gslb-ca" -keyout certs/ca/key.pem -out certs/ca/cert.pem \
+ -extensions default_ca_exts -quiet
+
+# Create client certificate for presenting to mTLS validating server
+# and sign with previously created root CA 
+# 
+openssl req -x509 -new -newkey ED25519 -noenc -config gen_certs/rootca.cnf \
+ -subj "/CN=cdns-gslb-client" -keyout certs/client/key.pem \
+ -out certs/client/cert.pem -CA certs/ca/cert.pem -CAkey certs/ca/key.pem \
+ -extensions client_req_exts -quiet
+
+# openssl verify -x509_strict -CAfile certs/ca/cert.pem certs/client/cert.pem
+
+# Create server certificate w/ extensions for validating
+# presented client identity certificate and sign w/ root CA (mTLS)
+#
+#openssl req -x509 -new -newkey ED25519 -noenc -config gen_certs/rootca.cnf \
+# -subj "/CN=cdns-gslb-server" -keyout certs/tls/key.pem \
+# -out certs/tls/cert.pem -CA certs/ca/cert.pem -CAkey certs/ca/key.pem \
+# -extensions server_req_exts -quiet
+
+# openssl verify -x509_strict -CAfile certs/ca/cert.pem certs/tls/cert.pem

--- a/tests/gen_certs/rootca.cnf
+++ b/tests/gen_certs/rootca.cnf
@@ -1,0 +1,45 @@
+[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+x509_extensions	    = server_req_exts
+default_days	    = 30
+preserve	        = no
+unique_subject	    = no
+policy		        = policy_cnonly
+
+[ policy_cnonly ]
+countryName		        = optional
+stateOrProvinceName	    = optional
+localityName		    = optional
+organizationName	    = optional
+organizationalUnitName	= optional
+commonName		        = supplied
+emailAddress		    = optional
+serialNumber	        = optional
+
+[ default_ca_exts ]
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always,issuer:always
+basicConstraints        = critical, CA:true
+keyUsage                = cRLSign, keyCertSign
+
+[ client_req_exts ]
+basicConstraints	    = CA:false
+subjectKeyIdentifier	= hash
+authorityKeyIdentifier	= keyid,issuer:always
+keyUsage                = digitalSignature
+extendedKeyUsage        = clientAuth
+subjectAltName          = @client_alt_names
+
+[ server_req_exts ]
+basicConstraints	    = CA:false
+subjectKeyIdentifier	= hash
+authorityKeyIdentifier	= keyid,issuer:always
+keyUsage                = digitalSignature,keyEncipherment
+extendedKeyUsage        = serverAuth
+
+[ client_alt_names ]
+DNS.1                   = cdns-gslb-client
+DNS.2                   = localhost
+IP.1                    = 172.16.0.9

--- a/tests/webapp/Dockerfile
+++ b/tests/webapp/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-slim
 
-RUN mkdir -p /app
+RUN mkdir /app
 
 COPY ./server.py /app/
 COPY ./init.sh /app/

--- a/tests/webapp/init.sh
+++ b/tests/webapp/init.sh
@@ -1,10 +1,24 @@
 #!/bin/sh
 
-if [ ! -f /app/certs/cert.pem ]; then
-  mkdir -p /app/certs
-  openssl req -x509 -newkey rsa:4096 -keyout /app/certs/key.pem -out /app/certs/cert.pem -days 365 -nodes -subj '/CN=localhost'
+# docker-compose depends_on is still too fast sometimes
+# adding a sleep 15s to make sure gen_certs is complete
+sleep 15s
+
+APP_NAME=${APP_NAME:-WebApp} # WebApplication1[0-2]
+cn_san=$(echo $APP_NAME | tr '[:upper:]' '[:lower:]')
+APP_IP=$(hostname -I)
+
+if [ ! -f "/certs/$cn_san/cert.pem" ]; then
+  mkdir -p "/certs/$cn_san"
+  # Create server certificate w/ extensions for validating
+  # presented client identity certificate and sign w/ root CA (mTLS)
+  #
+  openssl req -x509 -new -newkey ED25519 -noenc -config /app/certs/rootca.cnf \
+   -subj "/CN=$cn_san" -keyout "/certs/$cn_san/key.pem" \
+   -out "/certs/$cn_san/cert.pem" -CA /app/certs/ca/cert.pem \
+   -CAkey /app/certs/ca/key.pem -extensions server_req_exts \
+   -addext "subjectAltName=DNS:$cn_san,DNS:cdns-gslb-server,DNS:localhost,IP:$APP_IP" -quiet
+  cat /app/certs/ca/cert.pem >> "/certs/$cn_san/cert.pem"
 fi
 
-APP_NAME=${APP_NAME:-WebApp}
-
-python /app/server.py --certfile /app/certs/cert.pem --keyfile /app/certs/key.pem --name "$APP_NAME"
+python /app/server.py --cafile /app/certs/ca/cert.pem --certfile "/certs/$cn_san/cert.pem" --keyfile "/certs/$cn_san/key.pem" --name "$APP_NAME"

--- a/tests/webapp/init.sh
+++ b/tests/webapp/init.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-# docker-compose depends_on is still too fast sometimes
-# adding a sleep 15s to make sure gen_certs is complete
-sleep 15s
+# ensure the root ca cert exists before continuing
+while [ $(find /app/certs/ca/ -type f -name "*.pem" | wc -l) -lt 2 ]
+do
+  sleep 2s
+done
 
 APP_NAME=${APP_NAME:-WebApp} # WebApplication1[0-2]
 cn_san=$(echo $APP_NAME | tr '[:upper:]' '[:lower:]')

--- a/tests/webapp/server.py
+++ b/tests/webapp/server.py
@@ -29,7 +29,7 @@ def log(msg):
 class ThreadedHTTPServer(ThreadingMixIn, http.server.HTTPServer):
     daemon_threads = True
 
-def run_https_server(port, name, certfile, keyfile):
+def run_https_server(port, name, cafilepath, certfile, keyfile):
     class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             log(f"HTTP GET {self.path} from {self.client_address}")
@@ -49,8 +49,9 @@ def run_https_server(port, name, certfile, keyfile):
     log(f"Creating Threaded HTTPS server on 0.0.0.0:{port}")
     httpd = ThreadedHTTPServer(('0.0.0.0', port), SimpleHTTPRequestHandler)
     httpd_ref = httpd
-    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=cafilepath)
     context.load_cert_chain(certfile=certfile, keyfile=keyfile)
+    context.verify_mode = ssl.CERT_OPTIONAL
     httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     try:
         log("Starting Threaded HTTPS server (serve_forever)")
@@ -86,6 +87,7 @@ def main():
     log("Starting server.py main()")
     parser = argparse.ArgumentParser(description="HTTPS and optional gRPC Health Server")
     parser.add_argument('--port', type=int, default=443, help='Port to listen on (HTTPS)')
+    parser.add_argument('--cafile', type=str, required=True, help='Path to Root CA Certificate file')
     parser.add_argument('--certfile', type=str, required=True, help='Path to SSL certificate file')
     parser.add_argument('--keyfile', type=str, required=True, help='Path to SSL key file')
     parser.add_argument('--name', type=str, required=True, help='Name of the application')
@@ -104,7 +106,7 @@ def main():
     signal.signal(signal.SIGINT, handle_signal)
 
     threads = []
-    t1 = threading.Thread(target=run_https_server, args=(args.port, args.name, args.certfile, args.keyfile))
+    t1 = threading.Thread(target=run_https_server, args=(args.port, args.name, args.cafile, args.certfile, args.keyfile))
     t1.start()
     threads.append(t1)
 


### PR DESCRIPTION
Description

This PR extends the existing http healthcheck backend definition to include a private CA public cert (or chain), private client key and certificate for presenting as requested identity authentication

What’s new

Add support for mTLS (client) auth for https backends

Add support for TLS SNI (Server Name Indication)

Added ephemeral certificate generation for docker compose tests including rootCA for full TLS validation