### PR TITLE
refactor: migrate CI integration tests to an external shell script

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,7 @@ jobs:
         args: --timeout 3m --verbose
 
     - name: Test
-      run: make tests
+      run: make test-unit
 
     - name: Line of Code
       run: make stats

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -48,135 +48,16 @@ jobs:
     - name: Bench
       run: go test -bench .
 
-  integration_gslb:
+  integration_tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Docker Compose and dig
+      - name: Set up dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y docker-compose dnsutils
+          sudo apt-get install -y docker-compose dnsutils jq
 
-      - name: Start docker-compose.dev.yml
-        run: |
-          sudo docker-compose -f docker-compose.dev.yml up -d
-
-      - name: Wait for coredns_gslb to be ready
-        run: |
-          for i in {1..30}; do
-            dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short | grep -q '172.16.0.10' && exit 0
-            sleep 2
-          done
-          echo "coredns_gslb did not become ready in time" >&2
-          exit 1
-
-      - name: Wait for healthcheck to be ready (15s)
-        run: sleep 15
-
-      - name: Check initial dig (should be 172.16.0.10)
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
-
-      - name: Stop webapp10
-        run: sudo docker-compose -f docker-compose.dev.yml stop webapp10
-
-      - name: Wait for healthcheck to update (35s) # TTL + 5s
-        run: sleep 35
-
-      - name: Check dig after webapp10 stopped (should be 172.16.0.11)
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
-
-      - name: Restart webapp10
-        run: sudo docker-compose -f docker-compose.dev.yml start webapp10
-
-      - name: Wait for healthcheck to update (35s) # TTL + 5s
-        run: sleep 35
-
-      - name: Check dig after webapp10 restarted (should be 172.16.0.10)
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
-
-      - name: Check dig with a query coming from subnet 10.1.0.0/24
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.1.0.42/24)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
-
-      - name: Check dig with a query coming from subnet 10.2.0.0/24
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.2.0.7/24)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
-
-      - name: Check dig with a query coming from an US IP
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=8.8.8.8/24)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
-
-      - name: Check dig with a query coming from an FR IP
-        run: |
-          ip=$(dig -p 8053 @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=90.0.0.0/24)
-          echo "Got IP: $ip"
-          [ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
-            
-      - name: Show docker-compose logs on failure
-        if: failure()
-        run: sudo docker-compose -f docker-compose.dev.yml logs coredns_gslb
-
-      - name: Tear down
-        if: always()
-        run: sudo docker-compose -f docker-compose.dev.yml down -v  
-
-  integration_api:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Docker Compose and dig
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose dnsutils
-
-      - name: Start docker-compose.dev.yml
-        run: |
-          sudo docker-compose -f docker-compose.dev.yml up -d
-
-      - name: Wait for coredns_gslb to be ready
-        run: |
-          for i in {1..30}; do
-            dig -p 8053 @127.0.0.1 webapp.app-x.gslb.example.com +short | grep -q '172.16.0.10' && exit 0
-            sleep 2
-          done
-          echo "coredns_gslb did not become ready in time" >&2
-          exit 1
-
-      - name: Count number of zones
-        run: |
-          resp=$(curl -s -X GET http://127.0.0.1:8080/api/overview | jq 'keys | length')
-          echo "Got Nb zones: $resp"
-          [ "$resp" = "2" ] || (echo "Expected 2 zones, got $resp" && exit 1)
-            
-      - name: Count number of records
-        run: |
-          resp=$(curl -s -X GET http://127.0.0.1:8080/api/overview | jq 'map(length) | add')
-          echo "Got Nb records: $resp"
-          [ "$resp" = "7" ] || (echo "Expected 7 records, got $resp" && exit 1)
-
-      - name: Show docker-compose logs on failure
-        if: failure()
-        run: sudo docker-compose -f docker-compose.dev.yml logs coredns_gslb
-
-      - name: Tear down
-        if: always()
-        run: sudo docker-compose -f docker-compose.dev.yml down -v  
+      - name: Run Integration Tests
+        run: make test-integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,12 @@ make
 
 ## Running Unit Tests
 
+Run all unit tests
+
+~~~ bash
+make test-unit
+~~~
+
 Run a specific test
 
 ~~~ bash
@@ -131,6 +137,20 @@ You can run the entire integration test suite (failover, GeoIP, and API checks) 
 ~~~ bash
 make test-integration
 ~~~
+
+### Troubleshooting Port Conflicts
+
+If some ports (like `8080` or `8053`) are already in use on your host machine, you will see a Docker bind error. You can override these ports using environment variables:
+
+~~~ bash
+COREDNS_PORT_API=8082 COREDNS_PORT_TCP=8055 make test-integration
+~~~
+
+Supported variables:
+- `COREDNS_PORT_API` (default: `8080`)
+- `COREDNS_PORT_TCP` (default: `8053`)
+- `COREDNS_PORT_UDP` (default: `8053`)
+- `COREDNS_PORT_METRICS` (default: `9153`)
 
 ## Run linters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,14 @@ Run a specific test
 go test -timeout 10s -cover -v . -run TestGSLB_PickFailoverBackend
 ~~~
 
+## Running Integration Tests
+
+You can run the entire integration test suite (failover, GeoIP, and API checks) locally using:
+
+~~~ bash
+make test-integration
+~~~
+
 ## Run linters
 
 **Install make:**

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,18 @@ endif
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
-.PHONY: tests stats lint build clean
+.PHONY: tests test-integration stats lint build clean
 
 # Runs linters.
 lint:
 	$(GOPATH)/bin/golangci-lint run --config=.golangci.yml ./...
 
+test-integration:
+	@chmod +x tests/integration.sh
+	./tests/integration.sh
+
 tests:
+
 	@echo "Running tests..."
 	@go test -v -race -coverprofile=coverage.out -json ./... | tee test_output.json | \
 	jq -r 'select(.Output != null) | .Output' | sed '/^\s*$$/d' | sed 's/^[ \t]*//'

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
-.PHONY: tests test-integration stats lint build clean
+.PHONY: tests test-unit test-integration stats lint build clean
 
 # Runs linters.
 lint:
@@ -16,9 +16,12 @@ test-integration:
 	@chmod +x tests/integration.sh
 	./tests/integration.sh
 
-tests:
+# Runs all tests.
+tests: test-unit test-integration
 
-	@echo "Running tests..."
+# Runs unit tests.
+test-unit:
+	@echo "Running unit tests..."
 	@go test -v -race -coverprofile=coverage.out -json ./... | tee test_output.json | \
 	jq -r 'select(.Output != null) | .Output' | sed '/^\s*$$/d' | sed 's/^[ \t]*//'
 	go tool cover -func=coverage.out

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://img.shields.io/badge/go%20tests-187-green" alt="Go tests"/>
   <img src="https://img.shields.io/badge/go%20coverage-75.6%25-green" alt="Go coverage"/>
   <img src="https://img.shields.io/badge/lines%20of%20code-4543-blue" alt="Lines of code"/>
-  <img src="https://img.shields.io/badge/integration%20tests-9-blue" alt="Integration tests"/>
+  <img src="https://img.shields.io/badge/integration%20tests-16-blue" alt="Integration tests"/>
 </p>
 
 <p align="center">

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,10 +24,10 @@ services:
       - webapp12
     container_name: coredns
     ports:
-      - "8053:53/udp"
-      - "8053:53/tcp"
-      - "9153:9153/tcp"
-      - "8080:8080/tcp"
+      - "${COREDNS_PORT_UDP:-8053}:53/udp"
+      - "${COREDNS_PORT_TCP:-8053}:53/tcp"
+      - "${COREDNS_PORT_METRICS:-9153}:9153/tcp"
+      - "${COREDNS_PORT_API:-8080}:8080/tcp"
     volumes:
       - devcerts:/certs/:ro
       - ./tests/Corefile:/Corefile

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -2,6 +2,12 @@
 set -eo pipefail
 
 # 1. Determine Docker Compose command and configure ports
+if [ -n "${COREDNS_PORT_TCP:-}" ] && [ -z "${COREDNS_PORT_UDP:-}" ]; then
+    export COREDNS_PORT_UDP="${COREDNS_PORT_TCP}"
+elif [ -n "${COREDNS_PORT_UDP:-}" ] && [ -z "${COREDNS_PORT_TCP:-}" ]; then
+    export COREDNS_PORT_TCP="${COREDNS_PORT_UDP}"
+fi
+
 export COREDNS_PORT_UDP="${COREDNS_PORT_UDP:-8053}"
 export COREDNS_PORT_TCP="${COREDNS_PORT_TCP:-8053}"
 export COREDNS_PORT_METRICS="${COREDNS_PORT_METRICS:-9153}"
@@ -29,18 +35,42 @@ echo "=== Using Docker Compose command: $COMPOSE_CMD ==="
 echo "=== CoreDNS TCP Port: $COREDNS_PORT_TCP ==="
 echo "=== CoreDNS API Port: $COREDNS_PORT_API ==="
 
-# 2. Cleanup function for teardown on exit/failure
+# 2. Test counter variables and helper function
+TESTS_RUN=0
+TESTS_PASSED=0
+
+run_test() {
+    local name="$1"
+    shift
+    TESTS_RUN=$((TESTS_RUN + 1))
+    echo "Running test $((TESTS_RUN)): $name..."
+    if "$@"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo "✓ Pass"
+    else
+        echo "✗ Fail"
+        exit 1
+    fi
+    echo ""
+}
+
+# 3. Cleanup function for teardown on exit/failure
 cleanup() {
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "=== Test failed! Showing coredns_gslb logs: ==="
+        $COMPOSE_CMD logs coredns_gslb || true
+    fi
     echo "=== Cleaning up environment ==="
     $COMPOSE_CMD down -v || true
 }
 trap cleanup EXIT
 
-# 3. Start stack
+# 4. Start stack
 echo "=== Starting Dev Stack ==="
 $COMPOSE_CMD up -d
 
-# 4. Wait for coredns_gslb to be ready
+# 5. Wait for coredns_gslb to be ready
 echo "=== Waiting for CoreDNS GSLB to be ready ==="
 READY=false
 for i in {1..30}; do
@@ -61,13 +91,16 @@ fi
 echo "=== Waiting 15s for healthchecks to stabilize ==="
 sleep 15
 
-# 5. GSLB Failover Integration Tests
+# 6. GSLB Failover Integration Tests
 echo "=== Running GSLB Failover Tests ==="
 
-echo "Check initial dig (should be 172.16.0.10)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+test_initial_dig() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check initial dig (should be 172.16.0.10)" test_initial_dig
 
 echo "Stopping webapp10..."
 $COMPOSE_CMD stop webapp10
@@ -75,16 +108,21 @@ $COMPOSE_CMD stop webapp10
 echo "Waiting for healthcheck to update (35s)..."
 sleep 35
 
-echo "Check dig after webapp10 stopped (should be 172.16.0.11)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+test_dig_after_stop() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.11" ]
+}
+run_test "Check dig after webapp10 stopped (should be 172.16.0.11)" test_dig_after_stop
 
-# API check while webapp10 is down - API should reflect active changes or at least respond
-echo "Check API Overview while webapp10 is stopped..."
-resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
-echo "Got Nb zones: $resp"
-[ "$resp" = "2" ] || (echo "Expected 2 zones, got $resp" && exit 1)
+test_api_while_stopped() {
+    local resp
+    resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
+    echo "Got Nb zones: $resp"
+    [ "$resp" = "2" ]
+}
+run_test "Check API Overview while webapp10 is stopped (should be 2 zones)" test_api_while_stopped
 
 echo "Restarting webapp10..."
 $COMPOSE_CMD start webapp10
@@ -92,45 +130,125 @@ $COMPOSE_CMD start webapp10
 echo "Waiting for healthcheck to update (35s)..."
 sleep 35
 
-echo "Check dig after webapp10 restarted (should be 172.16.0.10)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+test_dig_after_restart() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check dig after webapp10 restarted (should be 172.16.0.10)" test_dig_after_restart
 
-# 6. GSLB GeoIP Integration Tests
+
+# 7. GSLB GeoIP Integration Tests
 echo "=== Running GSLB GeoIP Tests ==="
 
-echo "Check dig with query coming from subnet 10.1.0.0/24 (should be 172.16.0.10)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.1.0.42/24)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+test_geoip_subnet_10_1() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.1.0.42/24)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check dig with query coming from subnet 10.1.0.0/24 (should be 172.16.0.10)" test_geoip_subnet_10_1
 
-echo "Check dig with query coming from subnet 10.2.0.0/24 (should be 172.16.0.11)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.2.0.7/24)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+test_geoip_subnet_10_2() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.2.0.7/24)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.11" ]
+}
+run_test "Check dig with query coming from subnet 10.2.0.0/24 (should be 172.16.0.11)" test_geoip_subnet_10_2
 
-echo "Check dig with query coming from US IP (should be 172.16.0.11)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=8.8.8.8/24)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+test_geoip_us_country() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=8.8.8.8/24)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.11" ]
+}
+run_test "Check dig with query coming from US IP (should be 172.16.0.11)" test_geoip_us_country
 
-echo "Check dig with query coming from FR IP (should be 172.16.0.10)..."
-ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=90.0.0.0/24)
-echo "Got IP: $ip"
-[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+test_geoip_fr_country() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=90.0.0.0/24)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check dig with query coming from FR IP (should be 172.16.0.10)" test_geoip_fr_country
 
-# 7. API Integration Tests
+
+# 8. Additional Health Check & GeoIP City Tests
+echo "=== Running Additional GSLB Feature Tests ==="
+
+test_grpc_healthcheck() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-grpc.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.12" ]
+}
+run_test "Check gRPC Healthcheck resolution (should be webapp12: 172.16.0.12)" test_grpc_healthcheck
+
+test_mtls_healthcheck() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-mtls.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    echo "$ip" | grep -q '172.16.0.10' && echo "$ip" | grep -q '172.16.0.11'
+}
+run_test "Check mTLS Healthcheck resolution (should return both webapp10 and webapp11: 172.16.0.10 and 172.16.0.11)" test_mtls_healthcheck
+
+test_lua_healthcheck() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-lua.app-x.gslb.example.com +short)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check Lua Healthcheck resolution (should be webapp10: 172.16.0.10)" test_lua_healthcheck
+
+test_geoip_city_us_ca() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-city.app-y.gslb.example.com +short +subnet=9.9.9.9/32)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.10" ]
+}
+run_test "Check GeoIP City - US CA Berkeley Subdivision Fallback (should be 172.16.0.10)" test_geoip_city_us_ca
+
+test_geoip_city_ca_bc() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-city.app-y.gslb.example.com +short +subnet=24.80.0.1/32)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.12" ]
+}
+run_test "Check GeoIP City - CA BC Canada Country Fallback (should be 172.16.0.12)" test_geoip_city_ca_bc
+
+test_geoip_city_eu() {
+    local ip
+    ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-city.app-y.gslb.example.com +short +subnet=81.185.159.80/32)
+    echo "Got IP: $ip"
+    [ "$ip" = "172.16.0.13" ]
+}
+run_test "Check GeoIP City - Europe Continent Fallback (should be 172.16.0.13)" test_geoip_city_eu
+
+
+# 9. API Integration Tests
 echo "=== Running API Tests ==="
 
-echo "Check API Overview - count zones (should be 2)..."
-resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
-echo "Got Nb zones: $resp"
-[ "$resp" = "2" ] || (echo "Expected 2 zones, got $resp" && exit 1)
+test_api_zones() {
+    local resp
+    resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
+    echo "Got Nb zones: $resp"
+    [ "$resp" = "2" ]
+}
+run_test "Check API Overview - count zones (should be 2)" test_api_zones
 
-echo "Check API Overview - count records (should be 7)..."
-resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'map(length) | add')
-echo "Got Nb records: $resp"
-[ "$resp" = "7" ] || (echo "Expected 7 records, got $resp" && exit 1)
+test_api_records() {
+    local resp
+    resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'map(length) | add')
+    echo "Got Nb records: $resp"
+    [ "$resp" = "7" ]
+}
+run_test "Check API Overview - count records (should be 7)" test_api_records
 
-echo "=== All integration tests passed successfully! ==="
+
+# 10. Output Statistics
+echo "=== Integration Test Suite Completed ==="
+echo "Total executed integration tests: $TESTS_RUN"
+echo "Total passed integration tests: $TESTS_PASSED"
+echo "All $TESTS_PASSED integration tests passed successfully!"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+set -eo pipefail
+
+# 1. Determine Docker Compose command and configure ports
+export COREDNS_PORT_UDP="${COREDNS_PORT_UDP:-8053}"
+export COREDNS_PORT_TCP="${COREDNS_PORT_TCP:-8053}"
+export COREDNS_PORT_METRICS="${COREDNS_PORT_METRICS:-9153}"
+export COREDNS_PORT_API="${COREDNS_PORT_API:-8080}"
+
+DOCKER_COMPOSE="docker compose"
+if ! docker compose version >/dev/null 2>&1; then
+    if docker-compose version >/dev/null 2>&1; then
+        DOCKER_COMPOSE="docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' was found." >&2
+        exit 1
+    fi
+fi
+
+# Use sudo if docker commands require root permissions (detectable if docker run fails without sudo)
+SUDO=""
+if ! docker info >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+COMPOSE_CMD="$SUDO $DOCKER_COMPOSE -f docker-compose.dev.yml"
+
+echo "=== Using Docker Compose command: $COMPOSE_CMD ==="
+echo "=== CoreDNS TCP Port: $COREDNS_PORT_TCP ==="
+echo "=== CoreDNS API Port: $COREDNS_PORT_API ==="
+
+# 2. Cleanup function for teardown on exit/failure
+cleanup() {
+    echo "=== Cleaning up environment ==="
+    $COMPOSE_CMD down -v || true
+}
+trap cleanup EXIT
+
+# 3. Start stack
+echo "=== Starting Dev Stack ==="
+$COMPOSE_CMD up -d
+
+# 4. Wait for coredns_gslb to be ready
+echo "=== Waiting for CoreDNS GSLB to be ready ==="
+READY=false
+for i in {1..30}; do
+    if dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short | grep -q '172.16.0.10'; then
+        READY=true
+        break
+    fi
+    sleep 2
+done
+
+if [ "$READY" = false ]; then
+    echo "Error: coredns_gslb did not become ready in time" >&2
+    $COMPOSE_CMD logs coredns_gslb
+    exit 1
+fi
+
+# Wait for healthcheck to be fully ready
+echo "=== Waiting 15s for healthchecks to stabilize ==="
+sleep 15
+
+# 5. GSLB Failover Integration Tests
+echo "=== Running GSLB Failover Tests ==="
+
+echo "Check initial dig (should be 172.16.0.10)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+
+echo "Stopping webapp10..."
+$COMPOSE_CMD stop webapp10
+
+echo "Waiting for healthcheck to update (35s)..."
+sleep 35
+
+echo "Check dig after webapp10 stopped (should be 172.16.0.11)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+
+# API check while webapp10 is down - API should reflect active changes or at least respond
+echo "Check API Overview while webapp10 is stopped..."
+resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
+echo "Got Nb zones: $resp"
+[ "$resp" = "2" ] || (echo "Expected 2 zones, got $resp" && exit 1)
+
+echo "Restarting webapp10..."
+$COMPOSE_CMD start webapp10
+
+echo "Waiting for healthcheck to update (35s)..."
+sleep 35
+
+echo "Check dig after webapp10 restarted (should be 172.16.0.10)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp.app-x.gslb.example.com +short)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+
+# 6. GSLB GeoIP Integration Tests
+echo "=== Running GSLB GeoIP Tests ==="
+
+echo "Check dig with query coming from subnet 10.1.0.0/24 (should be 172.16.0.10)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.1.0.42/24)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+
+echo "Check dig with query coming from subnet 10.2.0.0/24 (should be 172.16.0.11)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-loc.app-y.gslb.example.com +short +subnet=10.2.0.7/24)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+
+echo "Check dig with query coming from US IP (should be 172.16.0.11)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=8.8.8.8/24)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.11" ] || (echo "Expected 172.16.0.11, got $ip" && exit 1)
+
+echo "Check dig with query coming from FR IP (should be 172.16.0.10)..."
+ip=$(dig -p "$COREDNS_PORT_TCP" @127.0.0.1 webapp-geoip-country.app-y.gslb.example.com +short +subnet=90.0.0.0/24)
+echo "Got IP: $ip"
+[ "$ip" = "172.16.0.10" ] || (echo "Expected 172.16.0.10, got $ip" && exit 1)
+
+# 7. API Integration Tests
+echo "=== Running API Tests ==="
+
+echo "Check API Overview - count zones (should be 2)..."
+resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'keys | length')
+echo "Got Nb zones: $resp"
+[ "$resp" = "2" ] || (echo "Expected 2 zones, got $resp" && exit 1)
+
+echo "Check API Overview - count records (should be 7)..."
+resp=$(curl -s -X GET http://127.0.0.1:"$COREDNS_PORT_API"/api/overview | jq 'map(length) | add')
+echo "Got Nb records: $resp"
+[ "$resp" = "7" ] || (echo "Expected 7 records, got $resp" && exit 1)
+
+echo "=== All integration tests passed successfully! ==="


### PR DESCRIPTION
fix #141 