### PR TITLE
fix: enforce /0 global ECS scope for fallthrough DNS responses to prevent improper caching of static records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <img src="https://goreportcard.com/badge/github.com/dmachard/coredns-gslb" alt="Go Report"/>
   <img src="https://img.shields.io/badge/go%20lint%20rules-8-green" alt="Go lint"/>
-  <img src="https://img.shields.io/badge/go%20tests-280-green" alt="Go tests"/>
+  <img src="https://img.shields.io/badge/go%20tests-281-green" alt="Go tests"/>
   <img src="https://img.shields.io/badge/go%20coverage-85.8%25-green" alt="Go coverage"/>
-  <img src="https://img.shields.io/badge/lines%20of%20code-5233-blue" alt="Lines of code"/>
+  <img src="https://img.shields.io/badge/lines%20of%20code-5230-blue" alt="Lines of code"/>
   <img src="https://img.shields.io/badge/integration%20tests-21-blue" alt="Integration tests"/>
 </p>
 

--- a/clientinfo.go
+++ b/clientinfo.go
@@ -36,7 +36,7 @@ type ecsResponseWriter struct {
 func (w *ecsResponseWriter) WriteMsg(res *dns.Msg) error {
 	if w.reqMsg != nil && len(w.reqMsg.Question) > 0 {
 		domain := strings.ToLower(dns.Fqdn(strings.TrimSuffix(w.reqMsg.Question[0].Name, ".")))
-		w.g.decorateWithECS(w.reqMsg, res, domain)
+		w.g.decorateWithECS(w.reqMsg, res, domain, true)
 	}
 	return w.ResponseWriter.WriteMsg(res)
 }

--- a/clientinfo_test.go
+++ b/clientinfo_test.go
@@ -67,4 +67,6 @@ func TestEcsResponseWriter(t *testing.T) {
 	assert.NotNil(t, foundEcs)
 	assert.Equal(t, "198.51.100.0", foundEcs.Address.String())
 	assert.Equal(t, uint8(24), foundEcs.SourceNetmask)
+	assert.Equal(t, uint8(0), foundEcs.SourceScope,
+		"ecsResponseWriter is for fallthrough responses, scope must always be /0")
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,7 +51,7 @@ gslb {
 * `geoip_maxmind <type> <path>`: Path to a MaxMind GeoLite2 database for GeoIP backend selection. `<type>` can be `country`, `city`, or `asn`.
 * `geoip_maxmind { ... }`: Block syntax for MaxMind DBs. Use `country_db`, `city_db`, and/or `asn_db` as keys inside the block to specify the database paths. Both syntaxes are supported and can be used interchangeably.
 * `geoip_custom`: Path to a YAML file mapping subnets to locations for GeoIP-based backend selection. Used for `geoip` mode (location-based routing). Subnets are pre-parsed on load and file reload to eliminate IP parsing overhead during DNS query resolution.
-* `use_edns_csubnet`: If set, the plugin will use the EDNS Client Subnet (ECS) option to determine the real client IP for GeoIP and logging, and will echo back the ECS option in DNS responses with the appropriate scope prefix-length per RFC 7871. Recommended for deployments behind DNS forwarders or public resolvers.
+* `use_edns_csubnet`: If set, the plugin will use the EDNS Client Subnet (ECS) option to determine the real client IP for GeoIP and logging, and will echo back the ECS option in DNS responses. See the [EDNS Client Subnet (ECS) Scope](#edns-client-subnet-ecs-scope) section below for details on RFC 7871 compliance.
 * `api_enable`: Enable or disable the HTTP API server (default: true). Set to `false` to disable the API endpoint.
 * `api_tls_cert`: Path to the TLS certificate file for the API server (optional, enables HTTPS if set with `api_tls_key`).
 * `api_tls_key`: Path to the TLS private key file for the API server (optional, enables HTTPS if set with `api_tls_cert`).
@@ -308,6 +308,13 @@ Example backend with all GeoIP location fields and health options
 ~~~
 
 For `continent`, use the exact MaxMind continent code from `Continent.Code`: `AF`, `AN`, `AS`, `EU`, `NA`, `OC`, `SA`.
+
+### EDNS Client Subnet (ECS) Scope
+
+When `use_edns_csubnet` is enabled, CoreDNS-GSLB adheres to **RFC 7871** to ensure correct caching behavior and prevent cache poisoning on public resolvers (such as Google Public DNS or Cloudflare):
+
+- **Geo-routed responses** (`geoip`, `geoip_affinity`, `hash`, `ip-hash`, `client-ip-hash` modes): The DNS response echoes the ECS option with the client's subnet mask as the **Source Scope** (e.g., `/24` or `/48`). This tells the resolver that the IP returned is specific to the client's location and should only be cached for clients in the same subnet.
+- **Static or fallback responses** (such as MX, SOA, NS, or TXT records that fall through to downstream plugins): The DNS response echoes the ECS option with a **Source Scope of `/0` (global)**. This signals to resolvers that the response is identical for all clients regardless of location, enabling global caching, reducing query load on the GSLB, and preventing cache fragmentation.
 
 ### API Server Options
 

--- a/gslb.go
+++ b/gslb.go
@@ -427,7 +427,7 @@ func (g *GSLB) handleTXTRecord(ctx context.Context, w dns.ResponseWriter, r *dns
 		response.Answer = append(response.Answer, txt)
 	}
 
-	g.decorateWithECS(r, response, domain)
+	g.decorateWithECS(r, response, domain, false)
 
 	// Send the DNS response with the multiple TXT records
 	if err := w.WriteMsg(response); err != nil {
@@ -600,7 +600,7 @@ func (g *GSLB) handleSVCBRecord(ctx context.Context, w dns.ResponseWriter, r *dn
 
 	response.Answer = append(response.Answer, rr)
 
-	g.decorateWithECS(r, response, domain)
+	g.decorateWithECS(r, response, domain, false)
 
 	err := w.WriteMsg(response)
 	if err != nil {
@@ -708,7 +708,7 @@ func (g *GSLB) sendAddressRecordResponse(w dns.ResponseWriter, r *dns.Msg, domai
 		}
 	}
 
-	g.decorateWithECS(r, response, domain)
+	g.decorateWithECS(r, response, domain, false)
 
 	err := w.WriteMsg(response)
 	if err != nil {
@@ -736,7 +736,7 @@ func (g *GSLB) sendRcodeResponse(w dns.ResponseWriter, r *dns.Msg, domain string
 	response := new(dns.Msg)
 	response.SetReply(r)
 	response.Rcode = rcode
-	g.decorateWithECS(r, response, domain)
+	g.decorateWithECS(r, response, domain, false)
 
 	err := w.WriteMsg(response)
 	if err != nil {
@@ -748,7 +748,7 @@ func (g *GSLB) sendRcodeResponse(w dns.ResponseWriter, r *dns.Msg, domain string
 	return dns.RcodeSuccess, nil
 }
 
-func (g *GSLB) decorateWithECS(r *dns.Msg, response *dns.Msg, domain string) {
+func (g *GSLB) decorateWithECS(r *dns.Msg, response *dns.Msg, domain string, forceGlobalScope bool) {
 	if !g.UseEDNSCSubnet {
 		return
 	}
@@ -767,20 +767,19 @@ func (g *GSLB) decorateWithECS(r *dns.Msg, response *dns.Msg, domain string) {
 		return
 	}
 
-	// Determine if the response is geo-specific
-	isGeo := false
-	record, _ := g.findRecord(domain)
-	if record != nil {
-		if record.Mode == "geoip" || record.Mode == "geoip_affinity" || record.Mode == "hash" || record.Mode == "ip-hash" || record.Mode == "client-ip-hash" {
-			isGeo = true
-		} else if len(g.LocationMap) > 0 {
-			isGeo = true
-		}
-	}
-
+	// Determine if the response is geo-specific.
+	// When forceGlobalScope is true, the response came from a downstream plugin
+	// (fallthrough) and is static/global — scope must be /0 per RFC 7871 §7.3.1.
 	sourceScope := uint8(0)
-	if isGeo {
-		sourceScope = reqEcs.SourceNetmask
+	if !forceGlobalScope {
+		record, _ := g.findRecord(domain)
+		if record != nil {
+			if record.Mode == "geoip" || record.Mode == "geoip_affinity" || record.Mode == "hash" || record.Mode == "ip-hash" || record.Mode == "client-ip-hash" {
+				sourceScope = reqEcs.SourceNetmask
+			} else if len(g.LocationMap) > 0 {
+				sourceScope = reqEcs.SourceNetmask
+			}
+		}
 	}
 
 	respEcs := &dns.EDNS0_SUBNET{

--- a/gslb_test.go
+++ b/gslb_test.go
@@ -1757,3 +1757,105 @@ func TestServeDNS_FallbackECS(t *testing.T) {
 		assert.Equal(t, uint8(24), respEcsNope.SourceNetmask)
 	}
 }
+
+// TestServeDNS_FallthroughECSScopeMustBeZero verifies that when a domain has a
+// geoip record in GSLB but the query type (MX, NS, SOA…) falls through to the
+// next plugin, the ECS scope in the response MUST be /0 (global), not the
+// client's prefix length. Static answers are identical for the whole world;
+// stamping them with a non-zero scope causes Google DNS to cache them per-subnet,
+// leading to overlapping-scope cache hazards (RFC 7871 §7.3.1).
+func TestServeDNS_FallthroughECSScopeMustBeZero(t *testing.T) {
+	// A geoip record exists for this domain — A queries are geo-routed
+	backend := &Backend{Address: "192.168.1.1", Enable: true, Alive: true, Priority: 1, Location: "eu-west"}
+	record := &Record{
+		Fqdn:      "registry.example.org.",
+		Mode:      "geoip",
+		Backends:  []BackendInterface{backend},
+		RecordTTL: 60,
+	}
+
+	n := &mockNextPlugin{}
+	g := &GSLB{
+		Zones:          map[string]string{"example.org.": "dummy.yml"},
+		Records:        map[string]map[string]*Record{"example.org.": {"registry.example.org.": record}},
+		UseEDNSCSubnet: true,
+		Next:           n,
+	}
+
+	getECS := func(msg *dns.Msg) *dns.EDNS0_SUBNET {
+		if msg == nil {
+			return nil
+		}
+		opt := msg.IsEdns0()
+		if opt == nil {
+			return nil
+		}
+		for _, o := range opt.Option {
+			if ecs, ok := o.(*dns.EDNS0_SUBNET); ok {
+				return ecs
+			}
+		}
+		return nil
+	}
+
+	makeECSQuery := func(name string, qtype uint16) *dns.Msg {
+		msg := new(dns.Msg)
+		msg.SetQuestion(name, qtype)
+		opt := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+		ecs := &dns.EDNS0_SUBNET{
+			Code:          dns.EDNS0SUBNET,
+			Address:       net.ParseIP("203.0.113.0"),
+			SourceNetmask: 24,
+			Family:        1,
+		}
+		opt.Option = append(opt.Option, ecs)
+		msg.Extra = append(msg.Extra, opt)
+		return msg
+	}
+
+	// 1. Sanity check: A query for the geoip domain — GSLB handles it directly,
+	//    scope SHOULD be /24 (geo-specific answer)
+	msgA := makeECSQuery("registry.example.org.", dns.TypeA)
+	wA := &mockResponseWriter{msg: new(dns.Msg), ip: net.ParseIP("127.0.0.1")}
+	_, err := g.ServeDNS(context.Background(), wA, msgA)
+	assert.NoError(t, err)
+
+	respEcsA := getECS(wA.msg)
+	assert.NotNil(t, respEcsA, "A response must have ECS")
+	if respEcsA != nil {
+		assert.Equal(t, uint8(24), respEcsA.SourceScope, "A response is geo-specific, scope must be /24")
+	}
+
+	// 2. MX query for the SAME geoip domain — falls through to next plugin.
+	//    The MX answer is static/global, scope MUST be /0.
+	n.called = false
+	msgMX := makeECSQuery("registry.example.org.", dns.TypeMX)
+	wMX := &mockResponseWriter{msg: new(dns.Msg), ip: net.ParseIP("127.0.0.1")}
+	_, err = g.ServeDNS(context.Background(), wMX, msgMX)
+	assert.NoError(t, err)
+	assert.True(t, n.called, "MX must fall through to next plugin")
+
+	respEcsMX := getECS(wMX.msg)
+	assert.NotNil(t, respEcsMX, "MX response must have ECS")
+	if respEcsMX != nil {
+		assert.Equal(t, "203.0.113.0", respEcsMX.Address.String())
+		assert.Equal(t, uint8(24), respEcsMX.SourceNetmask, "SourceNetmask must echo the query")
+		assert.Equal(t, uint8(0), respEcsMX.SourceScope,
+			"MX is static/global, scope must be /0 — not the client prefix")
+	}
+
+	// 3. SOA query for the SAME geoip domain — also falls through, scope MUST be /0.
+	n.called = false
+	msgSOA := makeECSQuery("registry.example.org.", dns.TypeSOA)
+	wSOA := &mockResponseWriter{msg: new(dns.Msg), ip: net.ParseIP("127.0.0.1")}
+	_, err = g.ServeDNS(context.Background(), wSOA, msgSOA)
+	assert.NoError(t, err)
+	assert.True(t, n.called, "SOA must fall through to next plugin")
+
+	respEcsSOA := getECS(wSOA.msg)
+	assert.NotNil(t, respEcsSOA, "SOA response must have ECS")
+	if respEcsSOA != nil {
+		assert.Equal(t, uint8(0), respEcsSOA.SourceScope,
+			"SOA is static/global, scope must be /0")
+	}
+}


### PR DESCRIPTION
related to #158 