### PR TITLE
fix: Use cancellable context for healthcheck goroutines of new record

### DIFF
--- a/gslb.go
+++ b/gslb.go
@@ -105,7 +105,9 @@ func (g *GSLB) updateRecords(ctx context.Context, newGSLB *GSLB) {
 				g.Records[zone][fqdn] = newRecord
 				log.Infof("Added new record for zone %s: %s", zone, fqdn)
 				newRecord.updateRecordHealthStatus()
-				go newRecord.scrapeBackends(ctx, g)
+				recordCtx, cancel := context.WithCancel(ctx)
+				newRecord.cancelFunc = cancel
+				go newRecord.scrapeBackends(recordCtx, g)
 			} else {
 				log.Infof("Reloading record %s in zone %s", fqdn, zone)
 				oldRecord.updateRecord(newRecord)

--- a/gslb_test.go
+++ b/gslb_test.go
@@ -68,6 +68,37 @@ func TestGSLB_RemainingEdgeCases(t *testing.T) {
 	gUpdate.updateRecords(context.Background(), newG)
 }
 
+func TestGSLB_UpdateRecords_NewRecordGetsCancelFunc(t *testing.T) {
+	g := &GSLB{
+		Records: map[string]map[string]*Record{
+			"example.org.": {},
+		},
+	}
+
+	newG := &GSLB{
+		Records: map[string]map[string]*Record{
+			"example.org.": {
+				"new.example.org.": {
+					Mode:           "failover",
+					ScrapeInterval: "1h",
+					Backends: []BackendInterface{
+						&Backend{Address: "192.168.1.1", Enable: true},
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	g.updateRecords(ctx, newG)
+
+	rec := g.Records["example.org."]["new.example.org."]
+	assert.NotNil(t, rec)
+	assert.NotNil(t, rec.cancelFunc, "new record must have a cancel func so it can be stopped on reload/shutdown")
+}
+
 func TestGSLB_InitializeRecordsFromFiles(t *testing.T) {
 	// Create a temp zone file
 	tmpDir, err := os.MkdirTemp("", "gslb_test_init_*")


### PR DESCRIPTION
Hello, after several attempts to switch to dynamic reload, I decided to check for inaccuracies and found:
 - When a record is added to a zone via dynamic config reload, updateRecords starts its health check loop without creating a per-record cancellable context.