### PR TITLE
fix: Warn instead of fail if location missing at location_map

### DIFF
--- a/docs/geoip.md
+++ b/docs/geoip.md
@@ -27,9 +27,9 @@ Create a YAML file mapping subnets to custom location tags:
 ```yaml
 subnets:
   - subnet: "10.0.0.0/24"
-    location: ["eu-west-1"]
-  - subnet: "192.168.1.0/24" 
-    location: ["us-east-1"]
+    location: "eu-west-1"
+  - subnet: "192.168.1.0/24"
+    location: "us-east-1"
 ```
 
 GSLB will map incoming client IPs belonging to these subnets to the defined location tag and direct traffic to backends tagged with the same `location` value.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -215,12 +215,19 @@ func (z *ZoneConfig) Validate(validLocations map[string]bool, globalProfiles map
 			seenAddresses[backend.Address] = true
 		}
 
-		// 2. Backends referencing location values not defined in the custom location map
+		// 2. Backends referencing location values not pinned in the custom location map.
+		// The location map only pins *specific* client subnets to a location, so it is
+		// expected to be partial: a backend location that is not a pin target stays
+		// usable through GeoIP affinity, failover and the API bulk operations. This is
+		// therefore reported as a warning (typo hint), never as a fatal error.
 		if len(validLocations) > 0 {
+			reported := make(map[string]bool)
 			for _, backend := range record.Backends {
-				if backend.Location != "" && !validLocations[backend.Location] {
-					errs = append(errs, fmt.Sprintf("backend '%s' in record '%s' references location '%s' not defined in custom location map", backend.Address, fqdn, backend.Location))
+				if backend.Location == "" || validLocations[backend.Location] || reported[backend.Location] {
+					continue
 				}
+				reported[backend.Location] = true
+				warns = append(warns, fmt.Sprintf("record '%s' references location '%s' which is not pinned to any subnet in the custom location map (subnet pinning will never select these backends)", fqdn, backend.Location))
 			}
 		}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,20 +67,33 @@ func TestZoneConfig_Validate(t *testing.T) {
 		assert.Len(t, warns, 3) // 2 for missing healthchecks, 1 for duplicate priority 0
 	})
 
-	t.Run("backend referencing undefined location", func(t *testing.T) {
+	t.Run("backend referencing unpinned location warns but does not fail", func(t *testing.T) {
 		yamlData := `records:
   test.example.com.:
     backends:
       - address: 1.2.3.4
         location: us-west-2
+      - address: 1.2.3.5
+        location: us-west-2
+      - address: 1.2.3.6
+        location: eu-west-1
 `
 		cfg, err := LoadZoneConfig([]byte(yamlData))
 		assert.NoError(t, err)
 
 		validLocations := map[string]bool{"eu-west-1": true}
-		errs, _ := cfg.Validate(validLocations, nil)
-		assert.Len(t, errs, 1)
-		assert.Contains(t, errs[0], "references location 'us-west-2' not defined in custom location map")
+		errs, warns := cfg.Validate(validLocations, nil)
+		assert.Empty(t, errs)
+
+		var locWarns []string
+		for _, w := range warns {
+			if strings.Contains(w, "not pinned to any subnet") {
+				locWarns = append(locWarns, w)
+			}
+		}
+		// One warning per distinct unpinned location, not per backend.
+		assert.Len(t, locWarns, 1)
+		assert.Contains(t, locWarns[0], "record 'test.example.com.' references location 'us-west-2'")
 	})
 
 	t.Run("duplicate priority values in failover mode", func(t *testing.T) {

--- a/setup_test.go
+++ b/setup_test.go
@@ -468,15 +468,17 @@ func TestSetupGSLB_ValidationErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid custom location map")
 	})
 
-	t.Run("backend referencing undefined location error", func(t *testing.T) {
-		invalidConfig := `records:
+	// A partial location map must not invalidate backends tagged with a location
+	// that no subnet pins to. See issue #207.
+	t.Run("backend referencing unpinned location does not block startup", func(t *testing.T) {
+		validConfig := `records:
   test.example.com.:
     backends:
       - address: 1.2.3.4
         location: us-west-2
 `
-		filePathZone := filepath.Join(tmpDir, "invalid_zone_loc.yml")
-		err := os.WriteFile(filePathZone, []byte(invalidConfig), 0644)
+		filePathZone := filepath.Join(tmpDir, "unpinned_zone_loc.yml")
+		err := os.WriteFile(filePathZone, []byte(validConfig), 0644)
 		assert.NoError(t, err)
 
 		locMap := `subnets:
@@ -493,8 +495,7 @@ func TestSetupGSLB_ValidationErrors(t *testing.T) {
 		}`
 		c := caddy.NewTestController("dns", configStr)
 		err = setup(c)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "references location 'us-west-2' not defined in custom location map")
+		assert.NoError(t, err)
 	})
 
 	t.Run("unresolved healthcheck profile error", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/dmachard/CoreDNS-GSLB/issues/207 and fixes found typo of array at example where it is not supported